### PR TITLE
chore(build): partially revert 18b07c0 to fix compiler warning

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -10,13 +10,13 @@
 	},
 	"type": "module",
 	"module": "dist/sylon.es.js",
-	"types": "dist/src/index.d.ts",
+	"types": "dist/index.d.ts",
 	"files": [
 		"dist"
 	],
 	"exports": {
 		".": {
-			"types": "./dist/src/index.d.ts",
+			"types": "./dist/index.d.ts",
 			"import": "./dist/sylon.es.js"
 		}
 	},

--- a/packages/react/src/components/Button/ToggleButton.tsx
+++ b/packages/react/src/components/Button/ToggleButton.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { type ReactNode, useState } from 'react';
 
 import { Button, type ButtonProps } from './Button';

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -27,6 +27,9 @@
 		"skipLibCheck": true,
 		"forceConsistentCasingInFileNames": true
 	},
+	"include": [
+		"src"
+	],
 	"exclude": [
 		"node_modules",
 		"dist",

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
 		lib: {
 			entry: path.resolve(__dirname, 'src/index.ts'),
 			name: 'sylon',
+			formats: ['es'],
 			fileName: (format) => `sylon.${format}.js`,
 		},
 	},


### PR DESCRIPTION
ESBuild doesn't recognize the 'use client' directive, which will cause the following error when compiling:

```
src/components/Button/ToggleButton.tsx (1:0) Error when using sourcemap for reporting an error: Can't resolve original location of error.
```
