### PR TITLE
fix(a11y): fix ARIA attributes for ToggleButton

### DIFF
--- a/packages/react/src/components/Button/ToggleButton.tsx
+++ b/packages/react/src/components/Button/ToggleButton.tsx
@@ -11,8 +11,7 @@ export const ToggleButton = ({ contentOn, contentOff, ...props }: ToggleButtonPr
 
 	return (
 		<Button
-			role='checkbox'
-			aria-checked={selected}
+			aria-pressed={selected}
 			onClick={() => setSelected(selected => !selected)}
 			{...props}
 		>


### PR DESCRIPTION
 - don't set checkbox role for ToggleButton, it's not an accurate descriptor
 - use `aria-pressed` instead of `aria-checked` to hold state

https://www.w3.org/WAI/ARIA/apg/patterns/button/