### PR TITLE
chore(compiler): improve settings for TSConfig + Vite

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Run tests
-        run: npm test:ci
+        run: npm run test:ci
         working-directory: packages/${{ matrix.directory }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,6 +67,31 @@ jobs:
       - name: Lint with ${{ matrix.tool }}
         run: npm run lint:${{ matrix.npm-cmd-suffix }}
 
+  test:
+    name: test (${{ matrix.package }})
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      matrix:
+        include:
+          - package: '@sylon/react'
+            directory: react
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: latest
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests
+        run: npm test:ci
+        working-directory: packages/${{ matrix.directory }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
   pkg-dry-run:
     name: pkg-dry-run (${{ matrix.package }})
     runs-on: ubuntu-latest

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -24,7 +24,11 @@
 		"build": "vite build",
 		"storybook": "storybook dev -p 6006",
 		"storybook-upgrade": "npx storybook@latest upgrade",
-		"build-storybook": "storybook build"
+		"build-storybook": "storybook build",
+		"test": "vitest --coverage",
+		"test:ci": "npm run test -- run",
+		"test:ui": "npm run test -- --ui",
+		"test:watch": "npm run test -- --watch"
 	},
 	"dependencies": {
 		"@tabler/icons-react": "^2.40.0",

--- a/packages/react/tests/compiler.test.ts
+++ b/packages/react/tests/compiler.test.ts
@@ -1,0 +1,52 @@
+import { ExternalOption, OutputOptions } from 'rollup';
+import { LibraryOptions } from 'vite';
+import { assertType,expect, test } from 'vitest';
+
+import tsConfig from './../tsconfig.json';
+import viteConfig from './../vite.config.ts';
+
+test('assert moduleResolution is "Bundler"', () => {
+	expect(tsConfig.compilerOptions.moduleResolution).toBe('Bundler');
+});
+
+test('assert Storybook files are not compiled', () => {
+	expect(tsConfig.exclude).toContain('src/**/*.stories.*');
+});
+
+test('assert compiler output is ESM', () => {
+	const lib = viteConfig.build?.lib as LibraryOptions;
+	expect(lib.formats).toContain('es');
+});
+
+test.each([
+	['tailwindcss'],
+	['react'],
+	['react-dom'],
+	['react/jsx-runtime'],
+])('assert peer dependency "%s" is excluded', async (dependency) => {
+	const { build } = viteConfig;
+	const externalDeps = build?.rollupOptions?.external;
+
+	expect(build?.rollupOptions?.external).not.toBeUndefined();
+	expect(build?.rollupOptions?.external).not.toBe([]);
+	assertType<ExternalOption[]>(externalDeps as any);
+
+	expect(externalDeps).toContain(dependency);
+});
+
+test.each([
+	['react', 'React'],
+	['tailwindcss', 'tailwindcss'],
+])('assert "%s" is setup as global with Rollup', async (dep, global) => {
+	const { build } = viteConfig;
+	const output = build?.rollupOptions?.output as OutputOptions;
+	const globals = output?.globals;
+
+	expect(globals).not.toBeUndefined();
+	expect(globals).not.toBe({});
+	assertType<Record<string, string>>(globals as any);
+
+	// look at each key-value pair
+	expect(globals).toHaveProperty(dep);
+	expect(globals?.[dep]).toBe(global);
+});

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		"jsx": "react-jsx",
 		"module": "ES2022",
-		"moduleResolution": "node",
+		"moduleResolution": "Bundler",
 		"target": "ES2022",
 		"useDefineForClassFields": true,
 		"resolveJsonModule": false,
@@ -33,6 +33,7 @@
 	"exclude": [
 		"node_modules",
 		"dist",
-		"*.config.cjs"
+		"*.config.cjs",
+		"src/**/*.stories.*"
 	]
 }

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -1,5 +1,6 @@
+import path from 'node:path';
+
 import react from '@vitejs/plugin-react';
-import path from 'path';
 import tailwindPlugin from 'tailwindcss';
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -2,6 +2,8 @@ import react from '@vitejs/plugin-react';
 import path from 'path';
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
+import { peerDependencies } from './package.json' assert { type: "json" };
+import tailwindPlugin from 'tailwindcss';
 
 export default defineConfig({
 	build: {
@@ -10,6 +12,26 @@ export default defineConfig({
 			name: 'sylon',
 			formats: ['es'],
 			fileName: (format) => `sylon.${format}.js`,
+		},
+		rollupOptions: {
+			external: [
+				...Object.keys(peerDependencies),
+				"react/jsx-runtime",
+				'tailwindcss',
+			],
+			output: {
+				globals: {
+					react: 'React',
+					'tailwindcss': 'tailwindcss',
+				}
+			}
+		},
+	},
+	css: {
+		postcss: {
+			plugins: [
+				tailwindPlugin(),
+			]
 		},
 	},
 	plugins: [

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -1,9 +1,10 @@
 import react from '@vitejs/plugin-react';
 import path from 'path';
+import tailwindPlugin from 'tailwindcss';
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
+
 import { peerDependencies } from './package.json';
-import tailwindPlugin from 'tailwindcss';
 
 export default defineConfig({
 	build: {
@@ -16,22 +17,22 @@ export default defineConfig({
 		rollupOptions: {
 			external: [
 				...Object.keys(peerDependencies),
-				"react/jsx-runtime",
+				'react/jsx-runtime',
 				'tailwindcss',
 			],
 			output: {
 				globals: {
 					react: 'React',
 					'tailwindcss': 'tailwindcss',
-				}
-			}
+				},
+			},
 		},
 	},
 	css: {
 		postcss: {
 			plugins: [
 				tailwindPlugin(),
-			]
+			],
 		},
 	},
 	plugins: [

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -2,7 +2,7 @@ import react from '@vitejs/plugin-react';
 import path from 'path';
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
-import { peerDependencies } from './package.json' assert { type: "json" };
+import { peerDependencies } from './package.json';
 import tailwindPlugin from 'tailwindcss';
 
 export default defineConfig({


### PR DESCRIPTION
- TSConfig: Don't compile Storybook files
- TSConfig: set moduleResolution to Bundler to let Vite handle it
- Vite: Make peer dependencies external from build via Rollup
- Vite: Configure global variables for React + TailwindCSS
- Vite: Configure TailwindCSS as PostCSS plugin

Fixes #86 